### PR TITLE
Update axios version to v0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ],
     "license": "MIT",
     "dependencies": {
-        "axios": "^0.18.0",
+        "axios": "^0.21.1",
         "babel-polyfill": "^6.26.0",
         "gatsby-source-filesystem": "^1.5.27",
         "lodash": "^4.17.5"


### PR DESCRIPTION
The following error currently occurs during Installation

```shell
npm WARN deprecated axios@0.18.1: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
npm ERR! Unexpected end of JSON input while parsing near '....2.0","slash":"^1.0.0'

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\USER\AppData\Roaming\npm-cache\_logs\2021-04-07T07_23_02_021Z-debug.log
```

Updating the axios version should fix this.